### PR TITLE
Fixed Bug in Command Line Argument Count Comparison

### DIFF
--- a/subjack.go
+++ b/subjack.go
@@ -231,7 +231,7 @@ func main() {
     flag.PrintDefaults()
   }
 
-  if flag.NArg() == 0 {
+  if flag.NFlag() == 0 {
     flag.Usage()
     os.Exit(1)
   }


### PR DESCRIPTION
NArg() returns the number of arguments remaining after flags have been processed. Since the flags have already been processed it returns 0, so we need to use NFlag() to check if there are any arguments.