### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Executable File
+main
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out


### PR DESCRIPTION
Currently building subjack will break the link with github forcing compiled binaries to have to be deleted before updating. It would be good to at least have 'main' in gitignore to prevent this. I've also added some other items of value, however feel free to limit this to compiled binaries if preferable.