### PR TITLE
added build path fallback in case env variable is not defined

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/build"
 	"os"
 
 	"github.com/haccer/subjack/subjack"
@@ -10,6 +11,9 @@ import (
 
 func main() {
 	GOPATH := os.Getenv("GOPATH")
+	if GOPATH == "" {
+		GOPATH = build.Default.GOPATH
+	}
 	Project := "/src/github.com/haccer/subjack/"
 	configFile := "fingerprints.json"
 	defaultConfig := GOPATH + Project + configFile


### PR DESCRIPTION
In go 1.8, the GOPATH env var is optional, whereas there is a default GOPATH exported via go/build