### PR TITLE
Add flag to define DNS server to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ func main() {
 	json.Unmarshal(config, &fingerprints)
 
 	subdomain := "dead.cody.su"
+	server := "8.8.8.8"
 	/* Use subjack's advanced detection to identify 
 	if the subdomain is able to be taken over. */
-	service := subjack.Identify(subdomain, false, 10, fingerprints)
+	service := subjack.Identify(subdomain, false, 10, server, fingerprints)
 
 	if service != "" {
 		service = strings.ToLower(service)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func main() {
 	Project := "/src/github.com/haccer/subjack/"
 	configFile := "fingerprints.json"
 	defaultConfig := GOPATH + Project + configFile
+	defaultDNS := "8.8.8.8"
 
 	o := subjack.Options{}
 
@@ -20,6 +21,7 @@ func main() {
 	flag.StringVar(&o.Wordlist, "w", "", "Path to wordlist.")
 	flag.IntVar(&o.Threads, "t", 10, "Number of concurrent threads (Default: 10).")
 	flag.IntVar(&o.Timeout, "timeout", 10, "Seconds to wait before connection timeout (Default: 10).")
+	flag.StringVar(&o.DNS, "dns", defaultDNS, "IP of DNS server to use (Default: 8.8.8.8).")
 	flag.BoolVar(&o.Ssl, "ssl", false, "Force HTTPS connections (May increase accuracy (Default: http://).")
 	flag.BoolVar(&o.All, "a", false, "Find those hidden gems by sending requests to every URL. (Default: Requests are only sent to URLs with identified CNAMEs).")
 	flag.BoolVar(&o.Verbose, "v", false, "Display more information per each request.")

--- a/subjack/dns.go
+++ b/subjack/dns.go
@@ -13,10 +13,10 @@ func (s *Subdomain) dns(o *Options) {
 	config := fingerprints(o.Config)
 
 	if o.All {
-		detect(s.Url, o.Output, o.Ssl, o.Verbose, o.Manual, o.Timeout, config)
+		detect(s.Url, o.Output, o.Ssl, o.Verbose, o.Manual, o.Timeout, o.DNS, config)
 	} else {
-		if VerifyCNAME(s.Url, config) {
-			detect(s.Url, o.Output, o.Ssl, o.Verbose, o.Manual, o.Timeout, config)
+		if VerifyCNAME(s.Url, o.DNS, config) {
+			detect(s.Url, o.Output, o.Ssl, o.Verbose, o.Manual, o.Timeout, o.DNS, config)
 		}
 
 		if o.Verbose {
@@ -36,11 +36,11 @@ func (s *Subdomain) dns(o *Options) {
 	}
 }
 
-func resolve(url string) (cname string) {
+func resolve(url string, server string) (cname string) {
 	cname = ""
 	d := new(dns.Msg)
 	d.SetQuestion(url+".", dns.TypeCNAME)
-	ret, err := dns.Exchange(d, "8.8.8.8:53")
+	ret, err := dns.Exchange(d, joinHost(server))
 	if err != nil {
 		return
 	}
@@ -54,10 +54,10 @@ func resolve(url string) (cname string) {
 	return cname
 }
 
-func nslookup(domain string) (nameservers []string) {
+func nslookup(domain string, server string) (nameservers []string) {
 	m := new(dns.Msg)
 	m.SetQuestion(dotDomain(domain), dns.TypeNS)
-	ret, err := dns.Exchange(m, "8.8.8.8:53")
+	ret, err := dns.Exchange(m, joinHost(server))
 	if err != nil {
 		return
 	}
@@ -83,8 +83,8 @@ func nxdomain(nameserver string) bool {
 	return false
 }
 
-func NS(domain, output string, verbose bool) {
-	nameservers := nslookup(domain)
+func NS(domain, server, output string, verbose bool) {
+	nameservers := nslookup(domain, server)
 	for _, ns := range nameservers {
 		if verbose {
 			msg := fmt.Sprintf("[*] %s: Nameserver is %s\n", domain, ns)

--- a/subjack/fingerprint.go
+++ b/subjack/fingerprint.go
@@ -19,8 +19,8 @@ type Fingerprints struct {
 * Triage step to check whether the CNAME matches
 * the fingerprinted CNAME of a vulnerable cloud service.
  */
-func VerifyCNAME(subdomain string, config []Fingerprints) (match bool) {
-	cname := resolve(subdomain)
+func VerifyCNAME(subdomain string, server string, config []Fingerprints) (match bool) {
+	cname := resolve(subdomain, server)
 	match = false
 
 VERIFY:
@@ -36,8 +36,8 @@ VERIFY:
 	return match
 }
 
-func detect(url, output string, ssl, verbose, manual bool, timeout int, config []Fingerprints) {
-	service := Identify(url, ssl, manual, timeout, config)
+func detect(url, output string, ssl, verbose, manual bool, timeout int, server string, config []Fingerprints) {
+	service := Identify(url, ssl, manual, timeout, server, config)
 
 	if service != "" {
 		result := fmt.Sprintf("[%s] %s\n", service, url)
@@ -75,10 +75,10 @@ func detect(url, output string, ssl, verbose, manual bool, timeout int, config [
 * is attached to a vulnerable cloud service and able to
 * be taken over.
  */
-func Identify(subdomain string, forceSSL, manual bool, timeout int, fingerprints []Fingerprints) (service string) {
+func Identify(subdomain string, forceSSL, manual bool, timeout int, server string, fingerprints []Fingerprints) (service string) {
 	body := get(subdomain, forceSSL, timeout)
 
-	cname := resolve(subdomain)
+	cname := resolve(subdomain, server)
 
 	if len(cname) <= 3 {
 		cname = ""

--- a/subjack/subjack.go
+++ b/subjack/subjack.go
@@ -16,6 +16,7 @@ type Options struct {
 	Verbose  bool
 	Config   string
 	Manual   bool
+	DNS      string
 }
 
 type Subdomain struct {


### PR DESCRIPTION
The DNS server used to query domains was hardcoded to `8.8.8.8`.
I added a new flag `-dns` to configure it and `8.8.8.8` is the default value if the flag is not used.