### PR TITLE
Fixed README example to include proper arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ func main() {
 	subdomain := "dead.cody.su"
 	/* Use subjack's advanced detection to identify 
 	if the subdomain is able to be taken over. */
-	service := subjack.Identify(subdomain, false, 10, fingerprints)
+	service := subjack.Identify(subdomain, false, false, 10, fingerprints)
 
 	if service != "" {
 		service = strings.ToLower(service)


### PR DESCRIPTION
- fixed README where subjack.Identify() example did not contain enough arguments