### PR TITLE
Fixes fingerprints.json: too many open files Error

### DIFF
--- a/subjack/dns.go
+++ b/subjack/dns.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *Subdomain) dns(o *Options) {
-	config := fingerprints(o.Config)
+	config := o.Fingerprints
 
 	if o.All {
 		detect(s.Url, o.Output, o.Ssl, o.Verbose, o.Manual, o.Timeout, config)

--- a/subjack/file.go
+++ b/subjack/file.go
@@ -106,6 +106,8 @@ func writeJSON(service, url, output string) {
 		log.Fatalln(err)
 	}
 
+	defer wf.Close()
+
 	wf.Write(results)
 }
 

--- a/subjack/subjack.go
+++ b/subjack/subjack.go
@@ -6,16 +6,17 @@ import (
 )
 
 type Options struct {
-	Domain   string
-	Wordlist string
-	Threads  int
-	Timeout  int
-	Output   string
-	Ssl      bool
-	All      bool
-	Verbose  bool
-	Config   string
-	Manual   bool
+	Domain       string
+	Wordlist     string
+	Threads      int
+	Timeout      int
+	Output       string
+	Ssl          bool
+	All          bool
+	Verbose      bool
+	Config       string
+	Manual       bool
+	Fingerprints []Fingerprints
 }
 
 type Subdomain struct {
@@ -29,6 +30,7 @@ func Process(o *Options) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	o.Fingerprints = fingerprints(o.Config)
 
 	wg := new(sync.WaitGroup)
 


### PR DESCRIPTION
While running the tool with the following arguments the script would error due to a condition where too many open files occurred. 

    $ subjack -w targets.txt -t 100 -timeout 30 -o results.json -a

    ...

    2020/02/04 02:33:04 open /go//src/github.com/haccer/subjack/fingerprints.json: too many open files


After review, it appears that each goroutine within subjack.dns() would read the fingerprints file. Refactored the code to read the fingerprints.json file once and then pass the []Fingerprints struct into the goroutines.

This appears to be working well for me and likely has some performance gains as well.

- fixes fingerprints.json: too many open files condition by reading the file once and passing data into the goroutine functions