### PR TITLE
Add SSL services for zendesk

### DIFF
--- a/fingerprints.json
+++ b/fingerprints.json
@@ -340,6 +340,14 @@
 		"nxdomain": false
 	},
 	{
+		"service": "ssl-zendesk",
+		"cname": [
+			".ssl.zendesk.com"
+		],
+		"fingerprint": [],
+		"nxdomain": true
+	},
+	{
 		"service": "readme",
 		"cname": [
 			"readme.io"


### PR DESCRIPTION
Hello,

Thanks for this awesome project !!
I would like to add the ssl.zendesk.com to fingerprint.json.
It's cannot be an addition to zendesk because the behavior is not the same (nxdomain = true). Zendesk create this subdomain when the instance is mapped to a custom host mapping.

How to exploit :

- Check if xxx is available on zendesk then create the instance.
- Set Host mapping to 'malicious.com' and generate a certificate and add it to the zendesk instance (SSL conf.)
- The domain will normally appeared.
- The vulnerable domain will be link to your malicious instance (with a certificate error but nice).

https://support.zendesk.com/hc/en-us/community/posts/207580187-Host-Mapping-Issue
