### PR TITLE
Remove Feedpress and Statuspage

### DIFF
--- a/fingerprints.json
+++ b/fingerprints.json
@@ -110,32 +110,12 @@
 		"nxdomain": false
 	},
 	{
-		"service": "feedpress",
-		"cname": [
-			"redirect.feedpress.me"
-		],
-		"fingerprint": [
-			"The feed has not been found."
-		],
-		"nxdomain": false
-	},
-	{
 		"service": "shopify",
 		"cname": [
 			"myshopify.com"
 		],
 		"fingerprint": [
 			"Sorry, this shop is currently unavailable."
-		],
-		"nxdomain": false
-	},
-	{
-		"service": "statuspage",
-		"cname": [
-			"statuspage.io"
-		],
-		"fingerprint": [
-			"You are being <a href=\"https://www.statuspage.io\">redirected"
 		],
 		"nxdomain": false
 	},


### PR DESCRIPTION
Both services are no longer vulnerable to subdomain takeover. Refer to: https://github.com/EdOverflow/can-i-take-over-xyz/