### PR TITLE
add support for -d

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Examples:
 - `./subjack -w subdomains.txt -t 100 -timeout 30 -o results.txt -ssl`
 
 Options:
+- `-d test.com` if you want to test a single domain.
 - `-w domains.txt` is your list of subdomains.
 - `-t` is the number of threads (Default: 10 threads). 
 - `-timeout` is the seconds to wait before timeout connection (Default: 10 seconds).

--- a/subjack/subjack.go
+++ b/subjack/subjack.go
@@ -25,11 +25,21 @@ type Subdomain struct {
 
 /* Start processing subjack from the defined options. */
 func Process(o *Options) {
+	var list []string
+	var err error
+
 	urls := make(chan *Subdomain, o.Threads*10)
-	list, err := open(o.Wordlist)
+	
+	if(len(o.Domain) > 0){
+		list = append(list, o.Domain)
+	} else {
+		list, err = open(o.Wordlist)
+	}
+		
 	if err != nil {
 		log.Fatalln(err)
 	}
+	
 	o.Fingerprints = fingerprints(o.Config)
 
 	wg := new(sync.WaitGroup)


### PR DESCRIPTION
Hello! 
thanks for this great tool.

this little pr just add support for the existing but unused -d flag.

now you can run subjack -d test.com -v
![imagen](https://user-images.githubusercontent.com/5620128/98588876-2d518000-22ab-11eb-96b1-f22a627d5caa.png)

this could be useful if you are trying to test something or running automatizations.