### PR TITLE
Add Vercel fingerprint

### DIFF
--- a/fingerprints.json
+++ b/fingerprints.json
@@ -354,5 +354,15 @@
 			"Hello! Sorry, but the website you&rsquo;re looking for doesn&rsquo;t exist.</p>\n<a href=\"https://worksites.net/\">Learn more about Worksites.net"
 		],
 		"nxdomain": false
+	},
+	{
+			"service": "vercel",
+			"cname": [
+					""
+			],
+			"fingerprint": [
+					"The deployment could not be found on Vercel."
+			],
+			"nxdomain": false
 	}
 ]


### PR DESCRIPTION
This PR adds a fingerprint for domains hosted on Vercel. As pointed out by this submitter: https://github.com/EdOverflow/can-i-take-over-xyz/issues/183, Vercel is also vulnerable to subdomain takeover 😄 

I've stood up a domain at `dashdot.app` to verify that this fingerprint works. 